### PR TITLE
Make graphql peer dependency, allow 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "babel-core": "6.9.0",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-preset-stage-1": "^6.13.0"
+    "babel-preset-stage-1": "^6.13.0",
+    "graphql": ">=0.7.1"
   },
-  "dependencies": {
-    "graphql": "^0.7.1"
+  "peerDependencies": {
+    "graphql": ">=0.7.1"
   }
 }


### PR DESCRIPTION
This way, it will use the installed graphQL. For development, it adds the dependency as well.

Entirely untested 😁 